### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ We are also looking forward to your feedback and suggestions!
 
 
 ## ⭐ Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=TIGER-AI-Lab/OpenResearcher&type=date&legend=top-left)](https://www.star-history.com/#TIGER-AI-Lab/OpenResearcher&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=TIGER-AI-Lab/OpenResearcher&type=date&legend=top-left)](https://star-history.dera.page/#TIGER-AI-Lab/OpenResearcher&type=date&legend=top-left)
 
 <p align="right" style="font-size: 14px; margin-top: 20px;">
   <a href="#readme-top" style="text-decoration: none; font-weight: bold;">


### PR DESCRIPTION
The star history chart in our README is currently broken because the upstream service relies on the GitHub stargazer API, which has become restricted. This PR points the chart to the star-history.dera.page mirror, which uses an alternative data source that requires no API token, so the chart displays correctly again.